### PR TITLE
Fix link in create_logs

### DIFF
--- a/create_logs.Rmd
+++ b/create_logs.Rmd
@@ -177,7 +177,7 @@ data %>%
 	to_activitylog() -> tmp_act
 ```
 
-Note that the resource identifier is optional, and can be left out of the `eventlog` call if such an attribute does not exist in your data. If the activity instance id does not exist, some heuristics are available to generate it: [Missing activity instance identifier].
+Note that the resource identifier is optional, and can be left out of the `eventlog` call if such an attribute does not exist in your data. If the activity instance id does not exist, some heuristics are available to generate it: [Missing activity instance id].
 
 ### Scenario 3
 

--- a/create_logs.Rmd
+++ b/create_logs.Rmd
@@ -220,7 +220,7 @@ data %>%
 
 Note that we need an `eventlog` irrespective of which attribute values are differing, i.e. it can be resources, but also any additional variables you have in your data set. For the special case of resource values, it might be that a different resource executing events in the same activity instance is a data quality issue. If so, some functions can help you to identify this issue: [Inconsistent Resources].
 
-Again, if the activity instance id does not exist, some heuristics are available to generate it: [Missing activity instance identifier].
+Again, if the activity instance id does not exist, some heuristics are available to generate it: [Missing activity instance id].
 
 ## Typical problems
 


### PR DESCRIPTION
The link to the missing activity instance identifier section in the create_logs doc page did not work because the section had a slightly different name.
Fixed this by changing [Missing activity instance identifier] to [Missing activity instance id].